### PR TITLE
Add tokenURI and supply cap to CrownKey

### DIFF
--- a/contracts/contracts/CrownKey.sol
+++ b/contracts/contracts/CrownKey.sol
@@ -2,15 +2,30 @@
 pragma solidity ^0.8.9;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract CrownKey is ERC721, Ownable {
+contract CrownKey is ERC721, ERC721Burnable, Ownable {
     uint256 private _nextTokenId;
+    string private _baseTokenURI;
+    uint256 public immutable supplyCap;
 
-    constructor() ERC721("CrownKey", "CRNKY") {}
+    constructor(string memory baseURI_, uint256 supplyCap_) ERC721("CrownKey", "CRNKY") {
+        _baseTokenURI = baseURI_;
+        supplyCap = supplyCap_;
+    }
+
+    function setBaseURI(string memory baseURI_) public onlyOwner {
+        _baseTokenURI = baseURI_;
+    }
 
     function safeMint(address to) public onlyOwner {
+        require(_nextTokenId < supplyCap, "Max supply reached");
         uint256 tokenId = _nextTokenId++;
         _safeMint(to, tokenId);
+    }
+
+    function _baseURI() internal view override returns (string memory) {
+        return _baseTokenURI;
     }
 }

--- a/contracts/test/CrownKey.js
+++ b/contracts/test/CrownKey.js
@@ -1,0 +1,34 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("CrownKey", function () {
+  async function deployCrownKey() {
+    const [owner, other] = await ethers.getSigners();
+    const CrownKey = await ethers.getContractFactory("CrownKey");
+    const crownKey = await CrownKey.deploy("ipfs://base/", 1n); // supply cap 1
+    await crownKey.waitForDeployment();
+    return { crownKey, owner, other };
+  }
+
+  it("returns correct tokenURI", async function () {
+    const { crownKey, owner } = await deployCrownKey();
+    await crownKey.safeMint(owner.address);
+    expect(await crownKey.tokenURI(0n)).to.equal("ipfs://base/0");
+  });
+
+  it("enforces supply cap", async function () {
+    const { crownKey, owner } = await deployCrownKey();
+    await crownKey.safeMint(owner.address);
+    await expect(crownKey.safeMint(owner.address)).to.be.revertedWith(
+      "Max supply reached"
+    );
+  });
+
+  it("allows burning tokens", async function () {
+    const { crownKey, owner } = await deployCrownKey();
+    await crownKey.safeMint(owner.address);
+    await crownKey.burn(0n);
+    await expect(crownKey.ownerOf(0n)).to.be.reverted;
+  });
+});
+


### PR DESCRIPTION
## Summary
- add base token URI and supply cap with burn support to CrownKey NFT
- add tests for tokenURI, cap enforcement, and burning

## Testing
- `npm test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ac7175d08322a3bf0df483ce9391