### PR TITLE
Add example contract interaction script and doc links

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -1,0 +1,5 @@
+# Bot
+
+Python Discord witness.
+
+For an example of interacting with the CrownKey contract using ethers.js to mint a token, see [../contracts/scripts/interact.js](../contracts/scripts/interact.js).

--- a/contracts/scripts/interact.js
+++ b/contracts/scripts/interact.js
@@ -1,0 +1,24 @@
+const { ethers } = require("ethers");
+require("dotenv").config();
+
+async function main() {
+  const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
+  const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
+
+  const crownKeyAbi = require("../artifacts/contracts/CrownKey.sol/CrownKey.json").abi;
+  const crownKey = new ethers.Contract(
+    process.env.CROWNKEY_ADDRESS,
+    crownKeyAbi,
+    wallet
+  );
+
+  const tx = await crownKey.safeMint(wallet.address);
+  await tx.wait();
+
+  console.log(`Minted token to ${wallet.address}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/README.md
+++ b/web/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Contract Interaction
+
+See [../contracts/scripts/interact.js](../contracts/scripts/interact.js) for a script that uses ethers.js to connect to the CrownKey contract and mint a token.


### PR DESCRIPTION
## Summary
- add `contracts/scripts/interact.js` showing how to connect with ethers.js and mint a CrownKey token
- reference the interaction script from bot and web module READMEs

## Testing
- `npm test --workspace=contracts` *(fails: HH502: Couldn't download compiler version list)*
- `npm run lint --workspace=web`
- `python -m py_compile bot/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5ac722eb4832287f6641716b5c209